### PR TITLE
Add standalone agent support in endpoint menus

### DIFF
--- a/client/src/common/selector.ts
+++ b/client/src/common/selector.ts
@@ -5,6 +5,11 @@ export interface Endpoint {
   value: string;
   label: string;
   hasModels: boolean;
+  /**
+   * When set, represents a standalone agent associated with this endpoint.
+   * Selecting the endpoint should automatically select this agent id.
+   */
+  agentId?: string;
   models?: Array<{ name: string; isGlobal?: boolean }>;
   icon: React.ReactNode;
   agentNames?: Record<string, string>;

--- a/client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx
@@ -99,6 +99,43 @@ export function EndpointItem({ endpoint }: EndpointItemProps) {
     </div>
   );
 
+  if (endpoint.agentId) {
+    return (
+      <MenuItem
+        id={`endpoint-${endpoint.value}-menu`}
+        key={`endpoint-${endpoint.value}-item`}
+        onClick={() => handleSelectModel(endpoint, endpoint.agentId!)}
+        className="flex h-8 w-full cursor-pointer items-center justify-between rounded-xl px-3 py-2 text-sm"
+      >
+        <div className="group flex w-full min-w-0 items-center justify-between">
+          {renderIconLabel()}
+          <div className="flex items-center gap-2">
+            {endpointRequiresUserKey(endpoint.value) && (
+              <SettingsButton endpoint={endpoint} handleOpenKeyDialog={handleOpenKeyDialog} />
+            )}
+            {selectedEndpoint === endpoint.value && selectedModel === endpoint.agentId && (
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                className="block"
+              >
+                <path
+                  fillRule="evenodd"
+                  clipRule="evenodd"
+                  d="M2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12ZM16.0755 7.93219C16.5272 8.25003 16.6356 8.87383 16.3178 9.32549L11.5678 16.0755C11.3931 16.3237 11.1152 16.4792 10.8123 16.4981C10.5093 16.517 10.2142 16.3973 10.0101 16.1727L7.51006 13.4227C7.13855 13.014 7.16867 12.3816 7.57733 12.0101C7.98598 11.6386 8.61843 11.6687 8.98994 12.0773L10.6504 13.9039L14.6822 8.17451C15 7.72284 15.6238 7.61436 16.0755 7.93219Z"
+                  fill="currentColor"
+                />
+              </svg>
+            )}
+          </div>
+        </div>
+      </MenuItem>
+    );
+  }
+
   if (endpoint.hasModels) {
     const filteredModels = searchValue
       ? filterModels(

--- a/client/src/components/Chat/Menus/Endpoints/components/SearchResults.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/SearchResults.tsx
@@ -97,6 +97,42 @@ export function SearchResults({ results, localize, searchValue }: SearchResultsP
         } else {
           // For an endpoint item
           const endpoint = item as Endpoint;
+          if (endpoint.agentId) {
+            return (
+              <MenuItem
+                key={`endpoint-${endpoint.value}-search-item`}
+                onClick={() => handleSelectModel(endpoint, endpoint.agentId!)}
+                className="flex w-full cursor-pointer items-center justify-between rounded-xl px-3 py-2 text-sm"
+              >
+                <div className="flex items-center gap-2">
+                  {endpoint.icon && (
+                    <div className="flex items-center justify-center overflow-hidden rounded-full border border-gray-200 p-1 dark:border-gray-700" style={{ borderRadius: '50%' }}>
+                      {endpoint.icon}
+                    </div>
+                  )}
+                  <span>{endpoint.label}</span>
+                </div>
+                {selectedEndpoint === endpoint.value && selectedModel === endpoint.agentId && (
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="block"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      clipRule="evenodd"
+                      d="M2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12ZM16.0755 7.93219C16.5272 8.25003 16.6356 8.87383 16.3178 9.32549L11.5678 16.0755C11.3931 16.3237 11.1152 16.4792 10.8123 16.4981C10.5093 16.517 10.2142 16.3973 10.0101 16.1727L7.51006 13.4227C7.13855 13.014 7.16867 12.3816 7.57733 12.0101C7.98598 11.6386 8.61843 11.6687 8.98994 12.0773L10.6504 13.9039L14.6822 8.17451C15 7.72284 15.6238 7.61436 16.0755 7.93219Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                )}
+              </MenuItem>
+            );
+          }
+
           if (endpoint.hasModels && endpoint.models && endpoint.models.length > 0) {
             const lowerQuery = searchValue.toLowerCase();
             const filteredModels = endpoint.label.toLowerCase().includes(lowerQuery)

--- a/client/src/components/Chat/Menus/Endpoints/utils.ts
+++ b/client/src/components/Chat/Menus/Endpoints/utils.ts
@@ -184,6 +184,10 @@ export const getDisplayValue = ({
       return localize('com_ui_select_model');
     }
 
+    if (endpoint.agentId && endpoint.agentId === selectedValues.model) {
+      return endpoint.label;
+    }
+
     if (
       isAgentsEndpoint(endpoint.value) &&
       endpoint.agentNames &&


### PR DESCRIPTION
## Summary
- support standalone agent entries with `agentId`
- show menu item for standalone agents in endpoint list
- display endpoint label when a single agent is selected
- allow agent entries in search results

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `npm run test:client` *(fails: cross-env not found)*