### PR TITLE
Implement standalone agents label override

### DIFF
--- a/api/server/services/start/interface.js
+++ b/api/server/services/start/interface.js
@@ -3,6 +3,7 @@ const {
   Permissions,
   PermissionTypes,
   removeNullishValues,
+  applyAgentsStandalone,
 } = require('librechat-data-provider');
 const { updateAccessPermissions } = require('~/models/Role');
 const { logger } = require('~/config');
@@ -36,6 +37,7 @@ async function loadDefaultInterface(config, configDefaults, roleName = SystemRol
     prompts: interfaceConfig?.prompts ?? defaults.prompts,
     multiConvo: interfaceConfig?.multiConvo ?? defaults.multiConvo,
     agents: interfaceConfig?.agents ?? defaults.agents,
+    agentsStandalone: interfaceConfig?.agentsStandalone ?? defaults.agentsStandalone,
     temporaryChat: interfaceConfig?.temporaryChat ?? defaults.temporaryChat,
     runCode: interfaceConfig?.runCode ?? defaults.runCode,
     customWelcome: interfaceConfig?.customWelcome ?? defaults.customWelcome,
@@ -103,6 +105,8 @@ async function loadDefaultInterface(config, configDefaults, roleName = SystemRol
   if (i > 0) {
     logSettings();
   }
+
+  applyAgentsStandalone(loadedInterface.agentsStandalone);
 
   return loadedInterface;
 }

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -492,6 +492,7 @@ export const intefaceSchema = z
     presets: z.boolean().optional(),
     prompts: z.boolean().optional(),
     agents: z.boolean().optional(),
+    agentsStandalone: z.boolean().optional(),
     temporaryChat: z.boolean().optional(),
     runCode: z.boolean().optional(),
   })
@@ -505,6 +506,7 @@ export const intefaceSchema = z
     bookmarks: true,
     prompts: true,
     agents: true,
+    agentsStandalone: false,
     temporaryChat: true,
     runCode: true,
   });
@@ -565,6 +567,7 @@ export type TStartupConfig = {
   publicSharedLinksEnabled: boolean;
   analyticsGtmId?: string;
   instanceProjectId: string;
+  agentsStandalone?: boolean;
   bundlerURL?: string;
   staticBundlerURL?: string;
 };
@@ -710,6 +713,12 @@ export const alternateName = {
   [KnownEndpoints.ollama]: 'Ollama',
   [KnownEndpoints.deepseek]: 'DeepSeek',
   [KnownEndpoints.xai]: 'xAI',
+};
+
+export const applyAgentsStandalone = (agentsStandalone?: boolean) => {
+  if (agentsStandalone) {
+    alternateName[EModelEndpoint.agents] = '';
+  }
 };
 
 const sharedOpenAIModels = [


### PR DESCRIPTION
## Summary
- support `agentsStandalone` option in interface config
- hide Agents label via `applyAgentsStandalone`
- apply label override when loading interface config

## Testing
- `npm run test:api` *(fails: jest not found)*
- `npm run test -w packages/data-provider` *(fails: jest not found)*