### PR TITLE
Add agentsStandalone option

### DIFF
--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -70,6 +70,7 @@ interface:
   bookmarks: true
   multiConvo: true
   agents: true
+  agentsStandalone: false
 
 # Example Cloudflare turnstile (optional)
 #turnstile:

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -492,6 +492,7 @@ export const intefaceSchema = z
     presets: z.boolean().optional(),
     prompts: z.boolean().optional(),
     agents: z.boolean().optional(),
+    agentsStandalone: z.boolean().optional(),
     temporaryChat: z.boolean().optional(),
     runCode: z.boolean().optional(),
   })
@@ -505,6 +506,7 @@ export const intefaceSchema = z
     bookmarks: true,
     prompts: true,
     agents: true,
+    agentsStandalone: false,
     temporaryChat: true,
     runCode: true,
   });


### PR DESCRIPTION
## Summary
- extend `intefaceSchema` with `agentsStandalone`
- document `agentsStandalone` in config example

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*