### PR TITLE
Fix agent selection display for endpoints

### DIFF
--- a/client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx
@@ -102,9 +102,9 @@ export function EndpointItem({ endpoint }: EndpointItemProps) {
   if (endpoint.agentId) {
     return (
       <MenuItem
-        id={`endpoint-${endpoint.value}-menu`}
-        key={`endpoint-${endpoint.value}-item`}
-        onClick={() => handleSelectModel(endpoint, endpoint.agentId!)}
+        id={`endpoint-${endpoint.value}-${endpoint.agentId}-menu`}
+        key={`endpoint-${endpoint.value}-${endpoint.agentId}-item`}
+        onClick={() => handleSelectModel(endpoint, endpoint.agentId)}
         className="flex h-8 w-full cursor-pointer items-center justify-between rounded-xl px-3 py-2 text-sm"
       >
         <div className="group flex w-full min-w-0 items-center justify-between">

--- a/client/src/components/Chat/Menus/Endpoints/components/SearchResults.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/SearchResults.tsx
@@ -100,8 +100,8 @@ export function SearchResults({ results, localize, searchValue }: SearchResultsP
           if (endpoint.agentId) {
             return (
               <MenuItem
-                key={`endpoint-${endpoint.value}-search-item`}
-                onClick={() => handleSelectModel(endpoint, endpoint.agentId!)}
+                key={`endpoint-${endpoint.value}-${endpoint.agentId}-search-item`}
+                onClick={() => handleSelectModel(endpoint, endpoint.agentId)}
                 className="flex w-full cursor-pointer items-center justify-between rounded-xl px-3 py-2 text-sm"
               >
                 <div className="flex items-center gap-2">
@@ -236,7 +236,11 @@ export function SearchResults({ results, localize, searchValue }: SearchResultsP
             return (
               <MenuItem
                 key={`endpoint-${endpoint.value}${endpoint.agentId ? `-${endpoint.agentId}` : ''}-search-item`}
-                onClick={() => handleSelectEndpoint(endpoint)}
+                onClick={() =>
+                  endpoint.agentId
+                    ? handleSelectModel(endpoint, endpoint.agentId)
+                    : handleSelectEndpoint(endpoint)
+                }
                 className="flex w-full cursor-pointer items-center justify-between rounded-xl px-3 py-2 text-sm"
               >
                 <div className="flex items-center gap-2">

--- a/client/src/components/Chat/Menus/Endpoints/utils.ts
+++ b/client/src/components/Chat/Menus/Endpoints/utils.ts
@@ -184,7 +184,10 @@ export const getDisplayValue = ({
       return localize('com_ui_select_model');
     }
 
-    if (endpoint.agentId && endpoint.agentId === selectedValues.model) {
+    if (
+      endpoint.agentId &&
+      (selectedValues.model === endpoint.agentId || !selectedValues.model)
+    ) {
       return endpoint.label;
     }
 


### PR DESCRIPTION
## Summary
- handle standalone agent endpoints in EndpointItem
- improve agent search result handling
- display endpoint label when standalone agent selected

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `npm run test:client` *(fails: cross-env not found)*