### PR TITLE
Document agentsStandalone option

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,13 @@ Keep up with the latest updates by visiting the releases page and notes:
   </a>
 </p>
 
+## 🗂️ `agentsStandalone` Option
+
+Setting `agentsStandalone: true` removes the "Agents" group from the endpoint
+menu and lists each agent individually. Configure this in `librechat.yaml` or
+set the `AGENTS_STANDALONE` environment variable so all agents appear directly
+in the dropdown.
+
 ---
 
 ## ✨ Contributions

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -70,6 +70,8 @@ interface:
   bookmarks: true
   multiConvo: true
   agents: true
+  # Recommended: Set to true to display all agents directly
+  agentsStandalone: true
 
 # Example Registration Object Structure (optional)
 registration:


### PR DESCRIPTION
## Summary
- recommend enabling `agentsStandalone` in librechat.example.yaml
- explain the option in README

## Testing
- `git status --short`