### PR TITLE
Implement agentsStandalone option

### DIFF
--- a/api/server/services/start/interface.js
+++ b/api/server/services/start/interface.js
@@ -33,6 +33,8 @@ async function loadDefaultInterface(config, configDefaults, roleName = SystemRol
     prompts: interfaceConfig?.prompts ?? defaults.prompts,
     multiConvo: interfaceConfig?.multiConvo ?? defaults.multiConvo,
     agents: interfaceConfig?.agents ?? defaults.agents,
+    agentsStandalone:
+      interfaceConfig?.agentsStandalone ?? defaults.agentsStandalone,
     temporaryChat: interfaceConfig?.temporaryChat ?? defaults.temporaryChat,
     runCode: interfaceConfig?.runCode ?? defaults.runCode,
     customWelcome: interfaceConfig?.customWelcome ?? defaults.customWelcome,

--- a/client/src/components/Chat/Menus/Endpoints/MenuItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/MenuItem.tsx
@@ -18,6 +18,7 @@ type MenuItemProps = {
   selected: boolean;
   description?: string;
   userProvidesKey: boolean;
+  agentId?: string;
   // iconPath: string;
   // hoverContent?: string;
 };
@@ -28,6 +29,7 @@ const MenuItem: FC<MenuItemProps> = ({
   description,
   selected,
   userProvidesKey,
+  agentId,
   ...rest
 }) => {
   const modularChat = useRecoilValue(store.modularChat);
@@ -82,8 +84,14 @@ const MenuItem: FC<MenuItemProps> = ({
       });
       return;
     }
+    const convoTemplate: Partial<TConversation> = {
+      ...(template as Partial<TConversation>),
+    };
+    if (agentId) {
+      convoTemplate.agent_id = agentId;
+    }
     newConversation({
-      template: { ...(template as Partial<TConversation>) },
+      template: convoTemplate,
       keepAddedConvos: isModular,
     });
   };

--- a/client/src/components/Chat/Menus/EndpointsMenu.tsx
+++ b/client/src/components/Chat/Menus/EndpointsMenu.tsx
@@ -3,7 +3,7 @@ import { alternateName } from 'librechat-data-provider';
 import { Content, Portal, Root } from '@radix-ui/react-popover';
 import type { FC, KeyboardEvent } from 'react';
 import { useChatContext, useAgentsMapContext, useAssistantsMapContext } from '~/Providers';
-import { useGetEndpointsQuery } from '~/data-provider';
+import { useGetEndpointsQuery, useGetStartupConfig } from '~/data-provider';
 import { mapEndpoints, getEntity } from '~/utils';
 import EndpointItems from './Endpoints/MenuItems';
 import useLocalize from '~/hooks/useLocalize';
@@ -17,6 +17,7 @@ const EndpointsMenu: FC = () => {
   const localize = useLocalize();
   const agentsMap = useAgentsMapContext();
   const assistantMap = useAssistantsMapContext();
+  const { data: startupConfig } = useGetStartupConfig();
   const { conversation } = useChatContext();
   const { endpoint = '' } = conversation ?? {};
 
@@ -94,7 +95,13 @@ const EndpointsMenu: FC = () => {
             aria-label={localize('com_ui_endpoints_available')}
             className="mt-2 max-h-[65vh] min-w-[340px] overflow-y-auto rounded-lg border border-border-light bg-header-primary text-text-primary shadow-lg lg:max-h-[75vh]"
           >
-            <EndpointItems endpoints={endpoints} selected={endpoint} />
+            <EndpointItems
+              endpoints={endpoints}
+              selected={endpoint}
+              selectedAgentId={conversation?.agent_id}
+              agentsMap={agentsMap}
+              interfaceConfig={startupConfig?.interface}
+            />
           </Content>
         </div>
       </Portal>

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -483,6 +483,7 @@ export const intefaceSchema = z
     presets: z.boolean().optional(),
     prompts: z.boolean().optional(),
     agents: z.boolean().optional(),
+    agentsStandalone: z.boolean().optional(),
     temporaryChat: z.boolean().optional(),
     runCode: z.boolean().optional(),
   })
@@ -496,6 +497,7 @@ export const intefaceSchema = z
     bookmarks: true,
     prompts: true,
     agents: true,
+    agentsStandalone: false,
     temporaryChat: true,
     runCode: true,
   });


### PR DESCRIPTION
## Summary
- implement `agentsStandalone` in interface schema and default settings
- load new `agentsStandalone` field in server interface service
- support standalone agent entries in endpoints menu
- allow selecting an agent directly from endpoints menu

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `npm run test:client` *(fails: cross-env not found)*