### PR TITLE
Minimal agent-focused interface

### DIFF
--- a/client/src/components/Agents/AgentShowcase.tsx
+++ b/client/src/components/Agents/AgentShowcase.tsx
@@ -1,0 +1,31 @@
+import { useSelectAgent } from '~/hooks';
+import { useListAgentsQuery } from '~/data-provider';
+import { useLocalize } from '~/hooks';
+
+export default function AgentShowcase() {
+  const { onSelect } = useSelectAgent();
+  const { data } = useListAgentsQuery();
+  const localize = useLocalize();
+  const agents = data?.data ?? [];
+
+  if (!agents.length) {
+    return <div className="text-center text-sm text-text-secondary">{localize('com_agents_showcase_none')}</div>;
+  }
+
+  return (
+    <div className="mt-6 flex flex-wrap justify-center gap-4">
+      {agents.map((agent) => (
+        <button
+          key={agent.id}
+          onClick={() => onSelect(agent.id)}
+          className="flex w-36 flex-col items-center gap-2 rounded-xl border border-border-medium p-3 hover:bg-surface-tertiary"
+        >
+          {agent.avatar?.filepath && (
+            <img src={agent.avatar.filepath} alt={agent.name} className="h-12 w-12 rounded-full object-cover" />
+          )}
+          <span className="text-sm font-medium text-text-primary">{agent.name}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -35,6 +35,8 @@ import StopButton from './StopButton';
 import SendButton from './SendButton';
 import Mention from './Mention';
 import store from '~/store';
+import { useAuthContext } from '~/hooks';
+import { SystemRoles } from 'librechat-data-provider';
 
 const ChatForm = ({ index = 0 }) => {
   const submitButtonRef = useRef<HTMLButtonElement>(null);
@@ -49,6 +51,8 @@ const ChatForm = ({ index = 0 }) => {
   const automaticPlayback = useRecoilValue(store.automaticPlayback);
   const maximizeChatSpace = useRecoilValue(store.maximizeChatSpace);
   const [isTemporaryChat, setIsTemporaryChat] = useRecoilState<boolean>(store.isTemporary);
+
+  const { user } = useAuthContext();
 
   const isSearching = useRecoilValue(store.isSearching);
   const [showStopButton, setShowStopButton] = useRecoilState(store.showStopButtonByIndex(index));
@@ -184,10 +188,12 @@ const ChatForm = ({ index = 0 }) => {
           )}
           <PromptsCommand index={index} textAreaRef={textAreaRef} submitPrompt={submitPrompt} />
           <div className="transitional-all relative flex w-full flex-grow flex-col overflow-hidden rounded-3xl bg-surface-tertiary text-text-primary duration-200">
-            <TemporaryChat
-              isTemporaryChat={isTemporaryChat}
-              setIsTemporaryChat={setIsTemporaryChat}
-            />
+            {user?.role === SystemRoles.ADMIN && (
+              <TemporaryChat
+                isTemporaryChat={isTemporaryChat}
+                setIsTemporaryChat={setIsTemporaryChat}
+              />
+            )}
             <TextareaHeader addedConvo={addedConvo} setAddedConvo={setAddedConvo} />
             <FileFormWrapper disableInputs={disableInputs}>
               {endpoint && (

--- a/client/src/components/Chat/Input/Files/FileFormWrapper.tsx
+++ b/client/src/components/Chat/Input/Files/FileFormWrapper.tsx
@@ -8,6 +8,8 @@ import {
   fileConfig as defaultFileConfig,
 } from 'librechat-data-provider';
 import { useGetFileConfig } from '~/data-provider';
+import { SystemRoles } from 'librechat-data-provider';
+import { useAuthContext } from '~/hooks';
 import AttachFileMenu from './AttachFileMenu';
 import { useChatContext } from '~/Providers';
 import { useFileHandling } from '~/hooks';
@@ -26,6 +28,7 @@ function FileFormWrapper({
   const { files, setFiles, conversation, setFilesLoading } = useChatContext();
   const { endpoint: _endpoint, endpointType } = conversation ?? { endpoint: null };
   const isAgents = useMemo(() => isAgentsEndpoint(_endpoint), [_endpoint]);
+  const { user } = useAuthContext();
 
   const { handleFileChange, abortUpload } = useFileHandling();
 
@@ -43,6 +46,9 @@ function FileFormWrapper({
   const isUploadDisabled = (disableInputs || endpointFileConfig?.disabled) ?? false;
 
   const renderAttachFile = () => {
+    if (user?.role !== SystemRoles.ADMIN) {
+      return null;
+    }
     if (isAgents) {
       return (
         <AttachFileMenu

--- a/client/src/components/Chat/Landing.tsx
+++ b/client/src/components/Chat/Landing.tsx
@@ -14,6 +14,7 @@ import { useLocalize, useSubmitMessage } from '~/hooks';
 import { TooltipAnchor } from '~/components/ui';
 import { BirthdayIcon } from '~/components/svg';
 import ConvoStarter from './ConvoStarter';
+import AgentShowcase from '~/components/Agents/AgentShowcase';
 
 export default function Landing({ Header }: { Header?: ReactNode }) {
   const { conversation } = useChatContext();
@@ -146,6 +147,10 @@ export default function Landing({ Header }: { Header?: ReactNode }) {
                 />
               ))}
         </div>
+        <h2 className="mt-10 text-lg font-semibold text-text-primary">
+          {localize('com_agents_showcase_heading')}
+        </h2>
+        <AgentShowcase />
       </div>
     </div>
   );

--- a/client/src/components/SidePanel/SidePanelGroup.tsx
+++ b/client/src/components/SidePanel/SidePanelGroup.tsx
@@ -1,12 +1,12 @@
 import { useState, useRef, useCallback, useEffect, useMemo, memo } from 'react';
 import throttle from 'lodash/throttle';
 import { useRecoilValue } from 'recoil';
-import { getConfigDefaults } from 'librechat-data-provider';
+import { getConfigDefaults, SystemRoles } from 'librechat-data-provider';
 import type { ImperativePanelHandle } from 'react-resizable-panels';
 import { ResizableHandleAlt, ResizablePanel, ResizablePanelGroup } from '~/components/ui/Resizable';
 import { useGetStartupConfig } from '~/data-provider';
 import { normalizeLayout } from '~/utils';
-import { useMediaQuery } from '~/hooks';
+import { useMediaQuery, useAuthContext } from '~/hooks';
 import SidePanel from './SidePanel';
 import store from '~/store';
 
@@ -35,6 +35,8 @@ const SidePanelGroup = ({
     () => startupConfig?.interface ?? defaultInterface,
     [startupConfig],
   );
+
+  const { user } = useAuthContext();
 
   const panelRef = useRef<ImperativePanelHandle>(null);
   const [minSize, setMinSize] = useState(defaultMinSize);
@@ -114,7 +116,7 @@ const SidePanelGroup = ({
             </ResizablePanel>
           </>
         )}
-        {!hideSidePanel && interfaceConfig.sidePanel === true && (
+        {!hideSidePanel && interfaceConfig.sidePanel === true && user?.role === SystemRoles.ADMIN && (
           <SidePanel
             panelRef={panelRef}
             minSize={minSize}
@@ -131,20 +133,22 @@ const SidePanelGroup = ({
           />
         )}
       </ResizablePanelGroup>
-      <button
-        aria-label="Close right side panel"
-        className={`nav-mask ${!isCollapsed ? 'active' : ''}`}
-        onClick={() => {
-          setIsCollapsed(() => {
-            localStorage.setItem('fullPanelCollapse', 'true');
-            setFullCollapse(true);
-            setCollapsedSize(0);
-            setMinSize(0);
-            return false;
-          });
-          panelRef.current?.collapse();
-        }}
-      />
+      {user?.role === SystemRoles.ADMIN && (
+        <button
+          aria-label="Close right side panel"
+          className={`nav-mask ${!isCollapsed ? 'active' : ''}`}
+          onClick={() => {
+            setIsCollapsed(() => {
+              localStorage.setItem('fullPanelCollapse', 'true');
+              setFullCollapse(true);
+              setCollapsedSize(0);
+              setMinSize(0);
+              return false;
+            });
+            panelRef.current?.collapse();
+          }}
+        />
+      )}
     </>
   );
 };

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -848,4 +848,7 @@
   "com_ui_zoom": "Zoom",
   "com_user_message": "You",
   "com_warning_resubmit_unsupported": "Resubmitting the AI message is not supported for this endpoint."
+  "com_agents_showcase_heading": "Select an agent to start chatting",
+  "com_agents_showcase_none": "No agents available.",
 }
+

--- a/client/src/routes/Root.tsx
+++ b/client/src/routes/Root.tsx
@@ -13,6 +13,7 @@ import TermsAndConditionsModal from '~/components/ui/TermsAndConditionsModal';
 import { useUserTermsQuery, useGetStartupConfig } from '~/data-provider';
 import { Nav, MobileNav } from '~/components/Nav';
 import { Banner } from '~/components/Banners';
+import { SystemRoles } from 'librechat-data-provider';
 
 export default function Root() {
   const [showTerms, setShowTerms] = useState(false);
@@ -22,7 +23,7 @@ export default function Root() {
     return savedNavVisible !== null ? JSON.parse(savedNavVisible) : true;
   });
 
-  const { isAuthenticated, logout } = useAuthContext();
+  const { isAuthenticated, logout, user } = useAuthContext();
   const assistantsMap = useAssistantsMap({ isAuthenticated });
   const agentsMap = useAgentsMap({ isAuthenticated });
   const fileMap = useFileMap({ isAuthenticated });
@@ -62,9 +63,13 @@ export default function Root() {
               <Banner onHeightChange={setBannerHeight} />
               <div className="flex" style={{ height: `calc(100dvh - ${bannerHeight}px)` }}>
                 <div className="relative z-0 flex h-full w-full overflow-hidden">
-                  <Nav navVisible={navVisible} setNavVisible={setNavVisible} />
+                  {user?.role === SystemRoles.ADMIN && (
+                    <Nav navVisible={navVisible} setNavVisible={setNavVisible} />
+                  )}
                   <div className="relative flex h-full max-w-full flex-1 flex-col overflow-hidden">
-                    <MobileNav setNavVisible={setNavVisible} />
+                    {user?.role === SystemRoles.ADMIN && (
+                      <MobileNav setNavVisible={setNavVisible} />
+                    )}
                     <Outlet context={{ navVisible, setNavVisible } satisfies ContextType} />
                   </div>
                 </div>

--- a/librechat.agent.yaml
+++ b/librechat.agent.yaml
@@ -1,0 +1,18 @@
+version: 1.2.1
+interface:
+  endpointsMenu: false
+  modelSelect: false
+  parameters: false
+  sidePanel: true
+  presets: false
+  prompts: false
+  bookmarks: false
+  multiConvo: false
+  agents: true
+  agentsStandalone: true
+  temporaryChat: false
+  runCode: false
+fileConfig:
+  endpoints:
+    agents:
+      disabled: true


### PR DESCRIPTION
## Summary
- create `AgentShowcase` component for quick agent selection
- show agent list on landing screen
- hide navigation and side panel for non‑admin users
- disable uploads and temporary chats for non‑admins
- add `librechat.agent.yaml` with interface tweaks

## Testing
- `npm run test:client` *(fails: cross-env not found)*
- `npm run test:api` *(fails: cross-env not found)*
- `npm run format` *(fails: prettier plugin missing)*